### PR TITLE
add `{APP_NAME}_GITHUB_TOKEN` env-var to shell and powershell

### DIFF
--- a/cargo-dist-schema/src/lib.rs
+++ b/cargo-dist-schema/src/lib.rs
@@ -585,6 +585,8 @@ pub struct EnvironmentVariables {
     pub github_base_url_env_var: String,
     /// Environment variable to set the GitHub Enterprise base URL
     pub ghe_base_url_env_var: String,
+    /// Environment variable to set the GitHub BEARER token when fetching archives
+    pub github_token_env_var: String,
 }
 
 /// A Release of an Application
@@ -943,6 +945,7 @@ impl DistManifest {
             let no_modify_path_env_var = format!("{env_app_name}_NO_MODIFY_PATH");
             let github_base_url_env_var = format!("{env_app_name}_INSTALLER_GITHUB_BASE_URL");
             let ghe_base_url_env_var = format!("{env_app_name}_INSTALLER_GHE_BASE_URL");
+            let github_token_env_var = format!("{env_app_name}_GITHUB_TOKEN");
 
             let environment_variables = EnvironmentVariables {
                 install_dir_env_var,
@@ -951,6 +954,7 @@ impl DistManifest {
                 no_modify_path_env_var,
                 github_base_url_env_var,
                 ghe_base_url_env_var,
+                github_token_env_var,
             };
 
             self.releases.push(Release {

--- a/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
+++ b/cargo-dist-schema/src/snapshots/cargo_dist_schema__emit.snap
@@ -721,6 +721,7 @@ expression: json_schema
         "disable_update_env_var",
         "ghe_base_url_env_var",
         "github_base_url_env_var",
+        "github_token_env_var",
         "install_dir_env_var",
         "no_modify_path_env_var",
         "unmanaged_dir_env_var"
@@ -736,6 +737,10 @@ expression: json_schema
         },
         "github_base_url_env_var": {
           "description": "Environment variable to set the GitHub base URL",
+          "type": "string"
+        },
+        "github_token_env_var": {
+          "description": "Environment variable to set the GitHub BEARER token when fetching archives",
           "type": "string"
         },
         "install_dir_env_var": {

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -61,6 +61,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url{{ hosting.github.artifact_download_path }}"
 }
+$auth_token = $env:{{ env_vars.github_token_env_var }}
 
 $receipt = @"
 {{ receipt | tojson }}
@@ -218,6 +219,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"

--- a/cargo-dist/templates/installer/installer.ps1.j2
+++ b/cargo-dist/templates/installer/installer.ps1.j2
@@ -220,16 +220,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -1212,9 +1212,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -1204,15 +1204,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -46,6 +46,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="{{ '${' }}{{ env_vars.github_token_env_var }}:-}"
 
 read -r RECEIPT <<EORECEIPT
 {{ receipt | tojson }}
@@ -1200,6 +1201,10 @@ downloader() {
     elif check_cmd wget
     then _dld=wget
     else _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
     fi
 
     if [ "$1" = --check ]

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -1203,18 +1203,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AKAIKATANA_REPACK_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
 }
+$auth_token = $env:AKAIKATANA_REPACK_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1975,7 +1985,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AKAIKATANA_REPACK_GITHUB_TOKEN"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AKAIKATANA_REPACK_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
 }
+$auth_token = $env:AKAIKATANA_REPACK_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1975,7 +1985,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AKAIKATANA_REPACK_GITHUB_TOKEN"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1257,18 +1257,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1266,9 +1266,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -1258,15 +1258,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AKAIKATANA_REPACK_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1256,6 +1257,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1367,7 +1372,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AKAIKATANA_REPACK_GITHUB_TOKEN"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1262,15 +1262,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1645,16 +1647,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AKAIKATANA_REPACK_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1260,6 +1261,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1485,6 +1490,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
 }
+$auth_token = $env:AKAIKATANA_REPACK_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1638,6 +1644,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -2006,7 +2016,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AKAIKATANA_REPACK_GITHUB_TOKEN"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1261,18 +1261,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -1270,9 +1270,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1282,9 +1282,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1273,18 +1273,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AKAIKATANA_REPACK_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1272,6 +1273,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1509,6 +1514,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
 }
+$auth_token = $env:AKAIKATANA_REPACK_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1665,6 +1671,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -2033,7 +2043,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AKAIKATANA_REPACK_GITHUB_TOKEN"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -1274,15 +1274,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1672,16 +1674,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AKAIKATANA_REPACK_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/mistydemeo/akaikatana-repack/releases/download/v0.2.0"
 }
+$auth_token = $env:AKAIKATANA_REPACK_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"akaikatana-repack","name":"akaikatana-repack","owner":"mistydemeo","release_type":"github"},"version":"CENSORED"}
@@ -1619,6 +1625,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1987,7 +1997,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AKAIKATANA_REPACK_DISABLE_UPDATE",
         "no_modify_path_env_var": "AKAIKATANA_REPACK_NO_MODIFY_PATH",
         "github_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AKAIKATANA_REPACK_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AKAIKATANA_REPACK_GITHUB_TOKEN"
       },
       "display_name": "akaikatana-repack",
       "display": true,

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1626,16 +1628,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1316,15 +1316,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1692,16 +1694,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1315,18 +1315,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -1324,9 +1324,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1314,6 +1315,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1525,6 +1530,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1685,6 +1691,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3508,7 +3518,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1260,6 +1261,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1485,6 +1490,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1638,6 +1644,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3449,7 +3459,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1262,15 +1262,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1645,16 +1647,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1261,18 +1261,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -1270,9 +1270,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1260,6 +1261,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1489,6 +1494,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1642,6 +1648,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3451,7 +3461,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1261,18 +1261,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1270,9 +1270,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -1262,15 +1262,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1649,16 +1651,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1316,15 +1316,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1692,16 +1694,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1315,18 +1315,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -1324,9 +1324,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1314,6 +1315,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1525,6 +1530,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1685,6 +1691,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3508,7 +3518,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1316,15 +1316,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1692,16 +1694,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1315,18 +1315,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -1324,9 +1324,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1314,6 +1315,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1525,6 +1530,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1685,6 +1691,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3526,7 +3536,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1617,16 +1619,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1460,6 +1465,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1610,6 +1616,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3426,7 +3436,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1356,7 +1361,8 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1356,7 +1361,8 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1356,7 +1361,8 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1356,7 +1361,8 @@ download_binary_and_run_installer "$@" || exit 1
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1314,6 +1315,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1458,6 +1463,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1618,6 +1624,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1987,7 +1997,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1316,15 +1316,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1625,16 +1627,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1315,18 +1315,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -1324,9 +1324,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1180,15 +1180,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1469,16 +1471,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1188,9 +1188,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1178,6 +1179,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1322,6 +1327,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1462,6 +1468,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1831,7 +1841,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -1179,18 +1179,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_formula.snap
@@ -90,7 +90,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_custom_github_runners.snap
@@ -25,7 +25,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3415,7 +3425,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  axolotlsay-n
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch.snap
@@ -25,7 +25,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss.snap
@@ -25,7 +25,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dispatch_abyss_only.snap
@@ -24,7 +24,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1392,6 +1397,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1542,6 +1548,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1911,7 +1921,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1549,16 +1551,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -3223,9 +3223,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1613,16 +1615,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"
@@ -3214,15 +3215,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -3578,16 +3581,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -3214,18 +3216,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_JS_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1456,6 +1461,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2"
 }
+$auth_token = $env:AXOLOTLSAY_JS_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay-js","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1606,6 +1612,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -2005,6 +2015,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3202,6 +3213,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -3411,6 +3426,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay-hybrid/releases/download/v0.10.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay-hybrid","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -3561,6 +3577,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3929,7 +3949,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,
@@ -3967,7 +3988,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_JS_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_JS_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_JS_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_JS_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay-js",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_linux_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_linux_only.snap
@@ -73,7 +73,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_macos_x86_64_only.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_macos_x86_64_only.snap
@@ -75,7 +75,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1257,18 +1257,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1266,9 +1266,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -1258,15 +1258,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1254,6 +1255,10 @@ downloader() {
     elif check_cmd wget
     then _dld=wget
     else _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
     fi
 
     if [ "$1" = --check ]
@@ -2801,7 +2806,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1246,9 +1246,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1238,15 +1238,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -1237,18 +1237,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1234,6 +1235,10 @@ downloader() {
     elif check_cmd wget
     then _dld=wget
     else _dld='curl or wget' # to be used in error message of need_cmd
+    fi
+
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
     fi
 
     if [ "$1" = --check ]
@@ -2781,7 +2786,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals.snap
@@ -25,7 +25,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_locals_but_custom.snap
@@ -25,7 +25,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1261,18 +1261,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1270,9 +1270,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -1262,15 +1262,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1649,16 +1651,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1260,6 +1261,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1489,6 +1494,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1642,6 +1648,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3455,7 +3465,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1392,6 +1397,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1542,6 +1548,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1911,7 +1921,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1549,16 +1551,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1392,6 +1397,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1542,6 +1548,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1911,7 +1921,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1549,16 +1551,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_tag_namespace.snap
@@ -25,7 +25,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1619,6 +1625,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3428,7 +3438,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1626,16 +1628,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -3416,7 +3426,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1249,18 +1249,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1258,9 +1258,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -1250,15 +1250,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1614,16 +1616,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1248,6 +1249,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1457,6 +1462,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1607,6 +1613,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1976,7 +1986,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1254,9 +1254,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1246,15 +1246,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1611,16 +1613,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -1245,18 +1245,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1244,6 +1245,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1454,6 +1459,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1604,6 +1610,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1975,7 +1985,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1233,15 +1233,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1597,16 +1599,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1241,9 +1241,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -1232,18 +1232,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1231,6 +1232,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1440,6 +1445,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1590,6 +1596,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1952,7 +1962,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1254,9 +1254,9 @@ downloader() {
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL $_extra_args "$1" -o "$2"
+    then curl -sSfL "$_extra_args" "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget $_extra_args "$1" -O "$2"
+    then wget "$_extra_args" "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1246,15 +1246,17 @@ downloader() {
     fi
 
     if [ -n "${AUTH_TOKEN:-}" ]; then
-        echo "TODO"
+        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
+    else
+        _extra_args=''
     fi
 
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
-    then curl -sSfL "$1" -o "$2"
+    then curl -sSfL $_extra_args "$1" -o "$2"
     elif [ "$_dld" = wget ]
-    then wget "$1" -O "$2"
+    then wget $_extra_args "$1" -O "$2"
     else err "Unknown downloader"   # should not reach here
     fi
 }
@@ -1611,16 +1613,15 @@ function Download($download_url, $platforms) {
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
 
-  if ($auth_token) {
-    Write-Verbose "TODO"
-  }
-
   # Download and unpack!
   $url = "$download_url/$artifact_name"
   Write-Information "Downloading $app_name $app_version ($arch)"
   Write-Verbose "  from $url"
   Write-Verbose "  to $dir_path"
   $wc = New-Object Net.Webclient
+  if ($auth_token) {
+    $wc.Headers["Authorization"] = "Bearer $auth_token"
+  }
   $wc.downloadFile($url, $dir_path)
 
   Write-Verbose "Unpacking to $tmp"

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -1245,18 +1245,20 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
-    if [ -n "${AUTH_TOKEN:-}" ]; then
-        _extra_args="--header 'Authorization: Bearer ${AUTH_TOKEN}'"
-    else
-        _extra_args=''
-    fi
-
     if [ "$1" = --check ]
     then need_cmd "$_dld"
-    elif [ "$_dld" = curl ]
-    then curl -sSfL "$_extra_args" "$1" -o "$2"
-    elif [ "$_dld" = wget ]
-    then wget "$_extra_args" "$1" -O "$2"
+    elif [ "$_dld" = curl ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            curl -sSfL --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -o "$2"
+        else
+            curl -sSfL "$1" -o "$2"
+        fi
+    elif [ "$_dld" = wget ]; then
+        if [ -n "${AUTH_TOKEN:-}" ]; then
+            wget --header "Authorization: Bearer ${AUTH_TOKEN}" "$1" -O "$2"
+        else
+            wget "$1" -O "$2"
+        fi
     else err "Unknown downloader"   # should not reach here
     fi
 }

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -51,6 +51,7 @@ if [ -n "${UNMANAGED_INSTALL}" ]; then
     NO_MODIFY_PATH=1
     INSTALL_UPDATER=0
 fi
+AUTH_TOKEN="${AXOLOTLSAY_GITHUB_TOKEN:-}"
 
 read -r RECEIPT <<EORECEIPT
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1244,6 +1245,10 @@ downloader() {
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi
 
+    if [ -n "${AUTH_TOKEN:-}" ]; then
+        echo "TODO"
+    fi
+
     if [ "$1" = --check ]
     then need_cmd "$_dld"
     elif [ "$_dld" = curl ]
@@ -1454,6 +1459,7 @@ if ($env:INSTALLER_DOWNLOAD_URL) {
 } else {
   $ArtifactDownloadUrl = "$installer_base_url/axodotdev/axolotlsay/releases/download/v0.2.2"
 }
+$auth_token = $env:AXOLOTLSAY_GITHUB_TOKEN
 
 $receipt = @"
 {"binaries":["CARGO_DIST_BINS"],"binary_aliases":{},"cdylibs":["CARGO_DIST_DYLIBS"],"cstaticlibs":["CARGO_DIST_STATICLIBS"],"install_layout":"unspecified","install_prefix":"AXO_INSTALL_PREFIX","modify_path":true,"provider":{"source":"cargo-dist","version":"CENSORED"},"source":{"app_name":"axolotlsay","name":"axolotlsay","owner":"axodotdev","release_type":"github"},"version":"CENSORED"}
@@ -1604,6 +1610,10 @@ function Download($download_url, $platforms) {
   # Make a new temp dir to unpack things to
   $tmp = New-Temp-Dir
   $dir_path = "$tmp\$app_name$zip_ext"
+
+  if ($auth_token) {
+    Write-Verbose "TODO"
+  }
 
   # Download and unpack!
   $url = "$download_url/$artifact_name"
@@ -1975,7 +1985,8 @@ CENSORED (see https://github.com/axodotdev/cargo-dist/issues/1477)  source.tar.g
         "disable_update_env_var": "AXOLOTLSAY_DISABLE_UPDATE",
         "no_modify_path_env_var": "AXOLOTLSAY_NO_MODIFY_PATH",
         "github_base_url_env_var": "AXOLOTLSAY_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "AXOLOTLSAY_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "AXOLOTLSAY_GITHUB_TOKEN"
       },
       "display_name": "axolotlsay",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest.snap
@@ -21,7 +21,8 @@ stdout:
         "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
         "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH",
         "github_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "CARGO_DIST_SCHEMA_GITHUB_TOKEN"
       },
       "display_name": "cargo-dist-schema",
       "display": true,

--- a/cargo-dist/tests/snapshots/lib_manifest_slash.snap
+++ b/cargo-dist/tests/snapshots/lib_manifest_slash.snap
@@ -21,7 +21,8 @@ stdout:
         "disable_update_env_var": "CARGO_DIST_SCHEMA_DISABLE_UPDATE",
         "no_modify_path_env_var": "CARGO_DIST_SCHEMA_NO_MODIFY_PATH",
         "github_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "CARGO_DIST_SCHEMA_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "CARGO_DIST_SCHEMA_GITHUB_TOKEN"
       },
       "display_name": "cargo-dist-schema",
       "display": true,

--- a/cargo-dist/tests/snapshots/manifest.snap
+++ b/cargo-dist/tests/snapshots/manifest.snap
@@ -21,7 +21,8 @@ stdout:
         "disable_update_env_var": "CARGO_DIST_DISABLE_UPDATE",
         "no_modify_path_env_var": "CARGO_DIST_NO_MODIFY_PATH",
         "github_base_url_env_var": "CARGO_DIST_INSTALLER_GITHUB_BASE_URL",
-        "ghe_base_url_env_var": "CARGO_DIST_INSTALLER_GHE_BASE_URL"
+        "ghe_base_url_env_var": "CARGO_DIST_INSTALLER_GHE_BASE_URL",
+        "github_token_env_var": "CARGO_DIST_GITHUB_TOKEN"
       },
       "display_name": "cargo-dist",
       "display": true,


### PR DESCRIPTION
This sets "Authorization: Bearer ${APP_NAME}_GITHUB_TOKEN" in the headers of archive fetches from shell and powershell installers, if the env-var is set.

* [x] implement for curl command (shell)
* [x] implement for wget command (shell)
* [x] implement for Net.Webclient command (powershell)

Fixes #23 