### PR TITLE
add `packages` override for externally setting dist=true/false

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "axoproject"
-version = "0.28.4"
+version = "0.28.5-prerelease.1"
 dependencies = [
  "axoasset",
  "axoprocess",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist"
-version = "0.28.4"
+version = "0.28.5-prerelease.1"
 dependencies = [
  "axoasset",
  "axocli",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-dist-schema"
-version = "0.28.4"
+version = "0.28.5-prerelease.1"
 dependencies = [
  "camino",
  "gazenot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/astral-sh/cargo-dist"
 homepage = "https://github.com/astral-sh/cargo-dist"
-version = "0.28.4"
+version = "0.28.5-prerelease.1"
 rust-version = "1.74"
 
 [workspace.dependencies]
 # intra-workspace deps (you need to bump these versions when you cut releases too!
-cargo-dist-schema = { version = "=0.28.4", path = "cargo-dist-schema" }
-axoproject = { version = "=0.28.4", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
+cargo-dist-schema = { version = "=0.28.5-prerelease.1", path = "cargo-dist-schema" }
+axoproject = { version = "=0.28.5-prerelease.1", path = "axoproject", default-features = false, features = ["cargo-projects", "generic-projects", "npm-projects"] }
 
 # first-party deps
 axocli = { version = "0.2.0" }

--- a/axoproject/src/generic.rs
+++ b/axoproject/src/generic.rs
@@ -29,6 +29,8 @@ struct WorkspaceManifest {
 #[serde(rename_all = "kebab-case")]
 struct Workspace {
     members: Vec<WorkspaceMember>,
+    #[serde(default)]
+    packages: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -204,6 +206,12 @@ fn process_virtual_workspace(
                 let member_manifest_path = member_dir.join(DIST_PACKAGE_TOML);
                 let mut package = package_from(&member_manifest_path)?;
                 crate::merge_auto_includes(&mut package, &root_auto_includes);
+
+                // If `workspace.packages` is set, set distability overrides
+                if !workspace.packages.is_empty() {
+                    package.dist = Some(workspace.packages.contains(&package.name));
+                }
+
                 package_info.push(package);
             }
             #[cfg(feature = "cargo-projects")]
@@ -236,6 +244,11 @@ fn process_virtual_workspace(
                 merge_package_with_raw_generic(package, generic, paired_manifest);
             }
             crate::merge_auto_includes(package, &root_auto_includes);
+
+            // If `workspace.packages` is set, set distability overrides
+            if !workspace.packages.is_empty() {
+                package.dist = Some(workspace.packages.contains(&package.name));
+            }
         }
     }
 
@@ -384,6 +397,7 @@ fn process_package(
         cargo_package_id: None,
         npm_scope: None,
         axoupdater_versions: Default::default(),
+        dist: None,
     };
 
     // Load and apply auto-includes

--- a/axoproject/src/javascript.rs
+++ b/axoproject/src/javascript.rs
@@ -163,6 +163,7 @@ fn read_workspace(manifest_path: &Utf8Path) -> Result<WorkspaceStructure> {
         cargo_package_id: None,
         build_command,
         axoupdater_versions: Default::default(),
+        dist: None,
     };
     crate::merge_auto_includes(&mut info, &root_auto_includes);
 

--- a/axoproject/src/lib.rs
+++ b/axoproject/src/lib.rs
@@ -526,6 +526,8 @@ pub struct PackageInfo {
     pub npm_scope: Option<String>,
     /// Command to run to build this package
     pub build_command: Option<Vec<String>>,
+    /// Whether the workspace wants to force this package's distability
+    pub dist: Option<bool>,
 }
 
 impl PackageInfo {

--- a/axoproject/src/rust.rs
+++ b/axoproject/src/rust.rs
@@ -283,6 +283,7 @@ fn package_info(
         npm_scope: None,
         build_command: None,
         axoupdater_versions,
+        dist: None,
     };
 
     // Find files we might want to auto-include

--- a/cargo-dist/src/tests/mock.rs
+++ b/cargo-dist/src/tests/mock.rs
@@ -122,6 +122,7 @@ pub fn mock_package(name: &str, ver: &str) -> PackageInfo {
         npm_scope: None,
         build_command: None,
         axoupdater_versions: Default::default(),
+        dist: None,
     }
 }
 


### PR DESCRIPTION
This is necessary to allow the ruff/ty workspaces to have the same code with only an external dist-workspace.toml changing which packages are enabled.