### PR TITLE
feat: add option `binaries_in_root` as an option to specify that the archives should not contain a subdir with binaries

### DIFF
--- a/cargo-dist/src/config/v0.rs
+++ b/cargo-dist/src/config/v0.rs
@@ -163,6 +163,10 @@ pub struct DistMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unix_archive: Option<ZipStyle>,
 
+    /// Whether to always put the binaries in the root of the archive (defaults to false)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binaries_in_root: Option<bool>,
+
     /// Replace the app's name with this value for the npm package's name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub npm_package: Option<String>,
@@ -509,6 +513,7 @@ impl DistMetadata {
             auto_includes: _,
             windows_archive: _,
             unix_archive: _,
+            binaries_in_root: _,
             npm_package: _,
             npm_scope: _,
             checksum: _,
@@ -612,6 +617,7 @@ impl DistMetadata {
             auto_includes,
             windows_archive,
             unix_archive,
+            binaries_in_root,
             npm_package,
             npm_scope,
             checksum,
@@ -797,6 +803,9 @@ impl DistMetadata {
         }
         if unix_archive.is_none() {
             *unix_archive = workspace_config.unix_archive;
+        }
+        if binaries_in_root.is_none() {
+            *binaries_in_root = workspace_config.binaries_in_root;
         }
         if npm_package.is_none() {
             npm_package.clone_from(&workspace_config.npm_package);

--- a/cargo-dist/src/config/v0_to_v1.rs
+++ b/cargo-dist/src/config/v0_to_v1.rs
@@ -40,6 +40,7 @@ impl DistMetadata {
             msvc_crt_static,
             windows_archive,
             unix_archive,
+            binaries_in_root,
             npm_package,
             npm_scope,
             checksum,
@@ -106,6 +107,7 @@ impl DistMetadata {
             unix_archive,
             package_libraries,
             binaries,
+            binaries_in_root,
         });
         let needs_artifacts = archive_layer.is_some()
             || source_tarball.is_some()

--- a/cargo-dist/src/config/v1/artifacts/archives.rs
+++ b/cargo-dist/src/config/v1/artifacts/archives.rs
@@ -17,6 +17,8 @@ pub struct ArchiveConfig {
     pub package_libraries: Vec<LibraryStyle>,
     /// Binaries for a given platform
     pub binaries: SortedMap<String, Vec<String>>,
+    /// Whether to always put the binaries in the root of the archive
+    pub binaries_in_root: bool,
 }
 
 /// archive config (raw from config file)
@@ -54,6 +56,11 @@ pub struct ArchiveLayer {
     /// Binaries for a given platform
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binaries: Option<SortedMap<String, Vec<String>>>,
+    /// Whether to always put the binaries in the root of the archive
+    ///
+    /// Defaults to false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub binaries_in_root: Option<bool>,
 }
 
 impl ArchiveConfig {
@@ -66,6 +73,7 @@ impl ArchiveConfig {
             unix_archive: ZipStyle::Tar(CompressionImpl::Xzip),
             package_libraries: vec![],
             binaries: SortedMap::default(),
+            binaries_in_root: false,
         }
     }
 }
@@ -81,6 +89,7 @@ impl ApplyLayer for ArchiveConfig {
             unix_archive,
             package_libraries,
             binaries,
+            binaries_in_root,
         }: Self::Layer,
     ) {
         self.include.apply_val(include);
@@ -89,6 +98,7 @@ impl ApplyLayer for ArchiveConfig {
         self.unix_archive.apply_val(unix_archive);
         self.package_libraries.apply_val(package_libraries);
         self.binaries.apply_val(binaries);
+        self.binaries_in_root.apply_val(binaries_in_root);
     }
 }
 impl ApplyLayer for ArchiveLayer {
@@ -102,6 +112,7 @@ impl ApplyLayer for ArchiveLayer {
             unix_archive,
             package_libraries,
             binaries,
+            binaries_in_root,
         }: Self::Layer,
     ) {
         self.include.apply_opt(include);
@@ -110,5 +121,6 @@ impl ApplyLayer for ArchiveLayer {
         self.unix_archive.apply_opt(unix_archive);
         self.package_libraries.apply_opt(package_libraries);
         self.binaries.apply_opt(binaries);
+        self.binaries_in_root.apply_opt(binaries_in_root);
     }
 }

--- a/cargo-dist/src/init.rs
+++ b/cargo-dist/src/init.rs
@@ -495,6 +495,7 @@ fn get_new_dist_metadata(
             auto_includes: None,
             windows_archive: None,
             unix_archive: None,
+            binaries_in_root: None,
             npm_scope: None,
             npm_package: None,
             checksum: None,
@@ -998,6 +999,7 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         auto_includes,
         windows_archive,
         unix_archive,
+        binaries_in_root,
         npm_scope,
         npm_package,
         checksum,
@@ -1162,6 +1164,13 @@ fn apply_dist_to_metadata(metadata: &mut toml_edit::Item, meta: &DistMetadata) {
         "unix-archive",
         "# The archive format to use for non-windows builds (defaults .tar.xz)\n",
         unix_archive.map(|a| a.ext()),
+    );
+
+    apply_optional_value(
+        table,
+        "binaries-in-root",
+        "# Whether to place binaries in the root of the archive\n",
+        *binaries_in_root,
     );
 
     apply_optional_value(

--- a/cargo-dist/src/tasks.rs
+++ b/cargo-dist/src/tasks.rs
@@ -1883,6 +1883,9 @@ impl<'pkg_graph> DistGraphBuilder<'pkg_graph> {
         // (It's hard to strip-prefix zips, so making them both have an extra dir is annoying)
         let with_root = if let ZipStyle::Zip = zip_style {
             None
+        } else if release.config.artifacts.archives.binaries_in_root {
+            // User config override for having the binaries in the root of the archive
+            None
         } else {
             Some(Utf8PathBuf::from(artifact_dir_name.clone()))
         };


### PR DESCRIPTION
This is a patch from [prefix-dev](https://github.com/prefix-dev/pixi/issues/3902) 's fork of cargo-dist， which will allow cargo-dist to store bianry in the tar root without a extra subdir