### PR TITLE
fix: installer receipt for windows with posix shell

### DIFF
--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -79,6 +79,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path for receipt on Windows POSIX shells
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -93,7 +116,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/{{ app_name }}"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/{{ app_name }}"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/{{ app_name }}"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -617,7 +645,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/templates/installer/installer.sh.j2
+++ b/cargo-dist/templates/installer/installer.sh.j2
@@ -92,7 +92,7 @@ is_windows_posix() {
     esac
 }
 
-# Convert POSIX path to Windows path for receipt on Windows POSIX shells
+# Convert POSIX path to Windows path
 convert_path_for_receipt() {
     local _path="$1"
     if is_windows_posix && command -v cygpath > /dev/null 2>&1; then

--- a/cargo-dist/tests/snapshots/akaikatana_basic.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_basic.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/akaikatana-repack"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_bins.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_bins.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/akaikatana-repack"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_musl.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_musl.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/akaikatana-repack"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -671,7 +699,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_one_alias_among_many_binaries.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/akaikatana-repack"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -675,7 +703,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_two_bin_aliases.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/akaikatana-repack"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -687,7 +715,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/akaikatana_updaters.snap
+++ b/cargo-dist/tests/snapshots/akaikatana_updaters.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/akaikatana-repack"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/akaikatana-repack"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_abyss.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_action_commit.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -729,7 +757,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_alias.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -675,7 +703,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_alias_ignores_missing_bins.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -675,7 +703,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -729,7 +757,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_bins.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -729,7 +757,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_basic_lies.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_build_setup_steps.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2b.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_blake2s.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_256.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_checksum_sha3_512.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross1.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -729,7 +757,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_cross2.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -593,7 +621,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_disable_source_tarball.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_dist_url_override.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_edit_existing.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_generic_workspace_basic.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay-js"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay-js"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay-js"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout
@@ -2211,6 +2239,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -2225,7 +2276,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -2790,7 +2846,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_homebrew_packages.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_musl.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -671,7 +699,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_musl_no_gnu.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -651,7 +679,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_no_homebrew_publish.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_several_aliases.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -675,7 +703,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_ssldotcom_windows_sign_prod.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_updaters.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_global_build_job.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_host_job.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_local_build_job.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_plan_job.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
+++ b/cargo-dist/tests/snapshots/axolotlsay_user_publish_job.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_cargo_home.snap
+++ b/cargo-dist/tests/snapshots/install_path_cargo_home.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -663,7 +691,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_no_subdir.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_subdir.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_env_subdir_space_deeper.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
+++ b/cargo-dist/tests/snapshots/install_path_fallback_no_env_var_set.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -659,7 +687,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_deeper.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_min.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
+++ b/cargo-dist/tests/snapshots/install_path_home_subdir_space_deeper.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -646,7 +674,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout

--- a/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
+++ b/cargo-dist/tests/snapshots/install_path_no_fallback_taken.snap
@@ -84,6 +84,29 @@ get_home() {
         getent passwd "$(id -un)" | cut -d: -f6
     fi
 }
+
+# Check if running on Windows with POSIX-compliant shell (CYGWIN, MSYS, MINGW)
+is_windows_posix() {
+    case "$(uname)" in
+        CYGWIN*|MSYS*|MINGW*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Convert POSIX path to Windows path
+convert_path_for_receipt() {
+    local _path="$1"
+    if is_windows_posix && command -v cygpath > /dev/null 2>&1; then
+        # Use cygpath to convert path, then escape backslashes for JSON
+        cygpath -w "$_path" | sed 's/\\/\\\\/g'
+    else
+        echo "$_path"
+    fi
+}
 # The HOME reference to show in user output. If `$HOME` isn't set, we show the absolute path instead.
 get_home_expression() {
     if [ -n "${HOME:-}" ]; then
@@ -98,7 +121,12 @@ get_home_expression() {
 INFERRED_HOME=$(get_home)
 # shellcheck disable=SC2034
 INFERRED_HOME_EXPRESSION=$(get_home_expression)
-RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+# On Windows POSIX shells, use LOCALAPPDATA for receipt storage to match axoupdater expectations
+if is_windows_posix && [ -n "${LOCALAPPDATA:-}" ]; then
+    RECEIPT_HOME="$LOCALAPPDATA/axolotlsay"
+else
+    RECEIPT_HOME="${XDG_CONFIG_HOME:-$INFERRED_HOME/.config}/axolotlsay"
+fi
 
 usage() {
     # print help (this cat/EOF stuff is a "heredoc" string)
@@ -659,7 +687,7 @@ install() {
     _fish_env_script_path_expr="${_env_script_path_expr}.fish"
 
     # Replace the temporary cargo home with the calculated one
-    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$_receipt_install_dir,")
+    RECEIPT=$(echo "$RECEIPT" | sed "s,AXO_INSTALL_PREFIX,$(convert_path_for_receipt "$_receipt_install_dir"),")
     # Also replace the aliases with the arch-specific one
     RECEIPT=$(echo "$RECEIPT" | sed "s'\"binary_aliases\":{}'\"binary_aliases\":$(json_binary_aliases "$_arch")'")
     # And replace the install layout


### PR DESCRIPTION
Addresses https://github.com/astral-sh/uv/issues/12686.

## Notes
- The detection of POSIX shells on Windows is inspired by CPython's `venv` std lib implementation: https://github.com/python/cpython/blob/9f8ec95bb079c86c82a397516ea5da0b2cc1033d/Lib/venv/scripts/common/activate#L40
- Not really sure what's the best way to test this, having a dedicated MSYS2 test environment or similar would require some additional effort. There's https://github.com/msys2/setup-msys2 if CI tests are sufficient.